### PR TITLE
Add proper support for referencing msgpack and glog libs.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 project(mprpc)
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 2.8)
 
 set(VERSION_MAJOR 0)
 set(VERSION_MINOR 2)
@@ -33,28 +33,40 @@ IF(WIN32)
   SET(Boost_USE_STATIC_LIBS true)
 ENDIF(WIN32)
 
-INCLUDE(FindBoost)
-IF(Boost_FOUND)
-	SET(Boost_USE_MULTITHREADED ON)
-	SET(Boost_ADDITIONAL_VERSIONS "1.46.1" "1.40.0")
-	FIND_PACKAGE(Boost COMPONENTS system thread filesystem regex)
-	INCLUDE_DIRECTORIES(${Boost_INCLUDE_DIR})
-	LINK_DIRECTORIES(${Boost_LIBRARY_DIRS})
-ELSE(Boost_FOUND)
-	MESSAGE(FATAL_ERROR "The boost library was not found on your system.")
-ENDIF(Boost_FOUND)
+find_package (Boost REQUIRED COMPONENTS COMPONENTS system thread filesystem regex)
+find_package (OpenSSL QUIET)
+find_library (MSGPACK_LIBRARY NAMES "msgpack")
+if (MSGPACK_LIBRARY-NOTFOUND)
+    message (FATAL_ERROR "The msgpack library was not found on your system.")
+endif (MSGPACK_LIBRARY-NOTFOUND)
+find_path (MSGPACK_INCLUDE_DIR NAMES "msgpack.hpp" )
+if (MSGPACK_INCLUDE_DIR-NOTFOUND)
+    message (FATAL_ERROR "The msgpack header was not found on your system.")
+endif (MSGPACK_INCLUDE_DIR-NOTFOUND)
 
-find_package(OpenSSL QUIET)
-if (NOT OPENSSL_FOUND)
-  set(LIBCRYPTO "crypto")
-  set(LIBSSL "ssl")
-  set(OPENSSL_LIBRARIES ${LIBCRYPTO} ${LIBSSL})
-endif(NOT OPENSSL_FOUND)
-include_directories(${OPENSSL_INCLUDE_DIR})
+find_library (GLOG_LIBRARY NAMES "glog")
+if (GLOG_LIBRARY-NOTFOUND)
+    message (FATAL_ERROR "The glog library was not found on your system.")
+endif (GLOG_LIBRARY-NOTFOUND)
+find_path (GLOG_INCLUDE_DIR NAMES "logging.h" PATH_SUFFIXES glog)
+if (GLOG_INCLUDE_DIR-NOTFOUND)
+    message (FATAL_ERROR "The glog header was not found on your system.")
+endif (GLOG_INCLUDE_DIR-NOTFOUND)
+
+include_directories (${Boost_INCLUDE_DIRS}
+  ${MSGPACK_INCLUDE_DIR}
+  ${GLOG_INCLUDE_DIR}
+  ${OPENSSL_INCLUDE_DIRS})
+
+link_libraries (${Boost_LIBRARIES}
+    ${MSGPACK_LIBRARY}
+    ${GLOG_LIBRARY}
+    ${OPENSSL_LIBRARIES})
+
 ##########################################
 
 #Macro for the caller.hmpl & cclog.hmpl (any more ?)
-MACRO(mplex SOURCE) 
+MACRO(mplex SOURCE)
   set(OUTFILE ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE}.h)
   set(INFILE ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE}.hmpl)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,16 +1,10 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 2.8)
+
 PROJECT(test)
 
 set(CMAKE_CXX_FLAGS "-std=c++11 -g -Wall")
 
-find_library(LIBMSGPACK NAMES "libmsgpack.a" "msgpack" PATHS "../../lib")
-find_library(GLOG_LIBRARIES NAMES "glog" PATHS "../../lib")
-set(LIBMPRPC "${CMAKE_BINARY_DIR}/src/msgpack/rpc/libmprpc.a")
-
-link_libraries(${LIBMPRPC} ${LIBMSGPACK} ${GLOG_LIBRARIES}
-  ${Boost_SYSTEM_LIBRARY} ${Boost_THREAD_LIBRARY} ${LIBPTHREAD} ${LIBBOOST_THREAD}
-  ${Boost_PROGRAM_OPTIONS_LIBRARY} ${OPENSSL_LIBRARIES}
-) 
+link_libraries(mrpc-static)
 
 add_executable(address_test address_test.cc)
 add_executable(sync_call sync_call.cc)

--- a/unittest/CMakeLists.txt
+++ b/unittest/CMakeLists.txt
@@ -1,20 +1,13 @@
+cmake_minimum_required(VERSION 2.8)
+
 project(unittest)
-cmake_minimum_required(VERSION 2.6)
 
-# Set paths for required thirdparty libraries.
-set(CLIENT_GOOGLE_TEST_CPP ../../../thirdparty/gtest-1.5.0)
+find_package (GTest REQUIRED)
 
-find_library(GTEST gtest HINTS ${CLIENT_GOOGLE_TEST_CPP}/build)
-find_library(GTEST_MAIN gtest_main HINTS ${CLIENT_GOOGLE_TEST_CPP}/build)
-include_directories(${CLIENT_GOOGLE_TEST_CPP}/include/)
-
-find_library(LIBMSGPACK NAMES "libmsgpack.a" "msgpack" PATHS "../../lib")
-find_library(GLOG_LIBRARIES NAMES "glog" PATHS "../../lib")
+include_directories(${GTEST_INCLUDE_DIRS})
 
 file(GLOB_RECURSE SRCS_UNITTEST *.c*)
 add_executable(unittest ${SRCS_UNITTEST})
-TARGET_LINK_LIBRARIES(unittest mprpc ${LIBMSGPACK}
-    ${GLOG_LIBRARIES} ${GTEST_MAIN} ${GTEST}
-    ${Boost_SYSTEM_LIBRARY} ${Boost_THREAD_LIBRARY} ${LIBPTHREAD}
-    ${Boost_PROGRAM_OPTIONS_LIBRARY} ${OPENSSL_LIBRARIES}
+TARGET_LINK_LIBRARIES(unittest mprpc-static
+    ${GTEST_LIBRARIES}
 )


### PR DESCRIPTION
- Properly find msgpack and glog at configure time using available include and library paths.
- Use existing find_package mechanism for gtest
- Require CMake 2.8
