### PR TITLE
Convert to std::shared_ptr and std::bind() from Boost equivalents.

### DIFF
--- a/src/msgpack/rpc/client.cc
+++ b/src/msgpack/rpc/client.cc
@@ -19,6 +19,8 @@
 #include "session_impl.h"
 #include "transport/tcp.h"
 
+#include <functional>
+
 namespace msgpack {
 namespace rpc {
 
@@ -61,7 +63,7 @@ static bool step_timeout(weak_session ws)
 
 void client::start_timeout()
 {
-    m_pimpl->get_loop()->add_timer(1, boost::bind(&step_timeout,
+    m_pimpl->get_loop()->add_timer(1, std::bind(&step_timeout,
         weak_session(session::m_pimpl)));
 }
 

--- a/src/msgpack/rpc/future.cc
+++ b/src/msgpack/rpc/future.cc
@@ -94,10 +94,10 @@ void future_impl::attach_callback(callback_t func)
 {
     boost::mutex::scoped_lock lk(m_mutex);
 
-    assert(func.empty() == false);
+    assert(func);
     if (!m_session) {
         // callback_real(func, future(shared_from_this()));
-        m_loop->submit(boost::bind(&callback_real, func,
+        m_loop->submit(std::bind(&callback_real, func,
                        future(shared_from_this())));
     } else {
         m_callback = func;
@@ -114,9 +114,9 @@ void future_impl::set_result(object result, object error, auto_zone z)
 
     m_cond.notify_all();
 
-    if (!m_callback.empty()) {
+    if (m_callback) {
         callback_real(m_callback, future(shared_from_this()));
-        m_callback.clear();
+        m_callback = nullptr;
     }
 }
 
@@ -209,7 +209,7 @@ object future::error() const
     return m_pimpl->error();
 }
 
-future& future::attach_callback(boost::function<void (future)> func)
+future& future::attach_callback(std::function<void (future)> func)
 {
     m_pimpl->attach_callback(func);
     return *this;

--- a/src/msgpack/rpc/future.h
+++ b/src/msgpack/rpc/future.h
@@ -18,12 +18,12 @@
 #ifndef MSGPACK_RPC_FUTURE_H__
 #define MSGPACK_RPC_FUTURE_H__
 
-#include <boost/bind.hpp>
-#include <boost/function.hpp>
-#include <boost/shared_ptr.hpp>
-#include "types.h"
-#include "protocol.h"
 #include "impl_fwd.h"
+#include "protocol.h"
+#include "types.h"
+
+#include <functional>
+#include <utility> // for std::move()
 
 namespace msgpack {
 namespace rpc {
@@ -61,7 +61,7 @@ public:
     auto_zone& zone();
     const auto_zone& zone() const;
 
-    future& attach_callback(boost::function<void (future)> func);
+    future& attach_callback(std::function<void (future)> func);
 
     // for std::map and std::list
     bool operator< (const future& f) const;
@@ -111,7 +111,7 @@ public:
 };
 
 
-typedef boost::function<void (future)> callback_t;
+typedef std::function<void (future)> callback_t;
 
 
 template <typename T>

--- a/src/msgpack/rpc/future_impl.h
+++ b/src/msgpack/rpc/future_impl.h
@@ -20,15 +20,16 @@
 
 #include "future.h"
 #include "session_impl.h"
+
 #include <boost/thread.hpp>
 #include <boost/thread/condition_variable.hpp>
-#include <boost/enable_shared_from_this.hpp>
+#include <memory>
 
 namespace msgpack {
 namespace rpc {
 
 
-class future_impl : public boost::enable_shared_from_this<future_impl> {
+class future_impl : public std::enable_shared_from_this<future_impl> {
 public:
     future_impl(msgid_t msgid, shared_session s, loop lo);
     ~future_impl();

--- a/src/msgpack/rpc/impl_fwd.h
+++ b/src/msgpack/rpc/impl_fwd.h
@@ -18,8 +18,7 @@
 #ifndef MSGPACK_RPC_IMPL_H__
 #define MSGPACK_RPC_IMPL_H__
 
-#include <boost/shared_ptr.hpp>
-#include <boost/weak_ptr.hpp>
+#include <memory>
 
 namespace msgpack {
 namespace rpc {
@@ -27,26 +26,26 @@ namespace rpc {
 
 class future;
 class future_impl;
-typedef boost::shared_ptr<future_impl> shared_future;
+typedef std::shared_ptr<future_impl> shared_future;
 
 class session;
 class session_impl;
-typedef boost::shared_ptr<session_impl> shared_session;
-typedef boost::weak_ptr<session_impl> weak_session;
+typedef std::shared_ptr<session_impl> shared_session;
+typedef std::weak_ptr<session_impl> weak_session;
 
 class session_pool;
 class session_pool_impl;
-typedef boost::shared_ptr<session_pool_impl> shared_session_pool;
-typedef boost::weak_ptr<session_pool_impl> weak_session_pool;
+typedef std::shared_ptr<session_pool_impl> shared_session_pool;
+typedef std::weak_ptr<session_pool_impl> weak_session_pool;
 
 class server;
 class server_impl;
-typedef boost::shared_ptr<server_impl> shared_server;
-typedef boost::weak_ptr<server_impl> weak_server;
+typedef std::shared_ptr<server_impl> shared_server;
+typedef std::weak_ptr<server_impl> weak_server;
 
 class request;
 class request_impl;
-typedef boost::shared_ptr<request_impl> shared_request;
+typedef std::shared_ptr<request_impl> shared_request;
 
 
 }  // namespace rpc

--- a/src/msgpack/rpc/loop.h
+++ b/src/msgpack/rpc/loop.h
@@ -21,8 +21,9 @@
 #include <boost/asio.hpp>
 #include <boost/asio/deadline_timer.hpp>
 #include <boost/function.hpp>
-#include <boost/shared_ptr.hpp>
 #include <boost/thread.hpp>
+#include <functional>
+#include <memory>
 #include <vector>
 
 namespace msgpack {
@@ -43,14 +44,14 @@ public:
     void flush();
     void join();
     void end();
-    void submit(boost::function<void ()> callback);
+    void submit(std::function<void ()> callback);
 
-    int add_signal(int signo, boost::function<void
+    int add_signal(int signo, std::function<void
              (const boost::system::error_code& error, int signo)> handler);
     void remove_signal(int id);
 
-    void add_timer(int sec, boost::function<bool ()> handler);
-    void step_timeout(int sec, boost::function<bool ()> handler,
+    void add_timer(int sec, std::function<bool ()> handler);
+    void step_timeout(int sec, std::function<bool ()> handler,
              const boost::system::error_code& err);
 
 private:
@@ -62,11 +63,11 @@ private:
     boost::asio::signal_set m_sigset;
 #endif
     boost::asio::deadline_timer m_timer;
-    std::vector< boost::shared_ptr<boost::thread> > m_workers;
+    std::vector< std::shared_ptr<boost::thread> > m_workers;
 };
 
 
-class loop : public boost::shared_ptr<loop_impl> {
+class loop : public std::shared_ptr<loop_impl> {
 public:
     loop();
     ~loop();

--- a/src/msgpack/rpc/message_sendable.h
+++ b/src/msgpack/rpc/message_sendable.h
@@ -20,6 +20,8 @@
 
 #include "types.h"
 
+#include <memory>
+
 namespace msgpack {
 namespace rpc {
 
@@ -38,7 +40,7 @@ public:
     virtual void send_data(auto_vreflife vbuf) = 0;
 };
 
-typedef boost::shared_ptr<message_sendable> shared_message_sendable;
+typedef std::shared_ptr<message_sendable> shared_message_sendable;
 
 
 }  // namespace rpc

--- a/src/msgpack/rpc/server.cc
+++ b/src/msgpack/rpc/server.cc
@@ -35,7 +35,7 @@ server_impl::~server_impl()
     close();
 }
 
-void server_impl::serve(boost::shared_ptr<dispatcher> dp)
+void server_impl::serve(std::shared_ptr<dispatcher> dp)
 {
     m_dp = dp;
 }
@@ -97,7 +97,7 @@ server::~server()
     close();
 }
 
-void server::serve(boost::shared_ptr<dispatcher> dp)
+void server::serve(std::shared_ptr<dispatcher> dp)
 {
     static_cast<server_impl*>(m_pimpl.get())->serve(dp);
 }

--- a/src/msgpack/rpc/server.h
+++ b/src/msgpack/rpc/server.h
@@ -18,18 +18,16 @@
 #ifndef MSGPACK_RPC_SERVER_H__
 #define MSGPACK_RPC_SERVER_H__
 
-#include <boost/shared_ptr.hpp>
-#include <boost/make_shared.hpp>
-#include <boost/enable_shared_from_this.hpp>
-
-#include "session_pool.h"
 #include "request.h"
+#include "session_pool.h"
+
+#include <memory>
 
 namespace msgpack {
 namespace rpc {
 
 
-class dispatcher : public boost::enable_shared_from_this<dispatcher> {
+class dispatcher : public std::enable_shared_from_this<dispatcher> {
 public:
     virtual void dispatch(request req) = 0;
 };
@@ -41,7 +39,7 @@ public:
     server(const builder& b, loop lo = loop());
     virtual ~server();
 
-    void serve(boost::shared_ptr<dispatcher> dp);
+    void serve(std::shared_ptr<dispatcher> dp);
     void close();
 
     void listen(const listener& l);

--- a/src/msgpack/rpc/server_impl.h
+++ b/src/msgpack/rpc/server_impl.h
@@ -21,18 +21,20 @@
 #include "server.h"
 #include "session_pool_impl.h"
 
+#include <memory>
+
 namespace msgpack {
 namespace rpc {
 
 
 class server_impl : public session_pool_impl,
-    public boost::enable_shared_from_this<server_impl>
+    public std::enable_shared_from_this<server_impl>
 {
 public:
     server_impl(const builder&, loop lo);
     ~server_impl();
 
-    void serve(boost::shared_ptr<dispatcher> dp);
+    void serve(std::shared_ptr<dispatcher> dp);
     void listen(const listener& l);
     void close();
 
@@ -46,7 +48,7 @@ public:
     void on_notify(object method, object params, auto_zone z);
 
 private:
-    boost::shared_ptr<dispatcher> m_dp;
+    std::shared_ptr<dispatcher> m_dp;
     std::unique_ptr<server_transport> m_stran;
 
 private:

--- a/src/msgpack/rpc/session_impl.h
+++ b/src/msgpack/rpc/session_impl.h
@@ -18,18 +18,19 @@
 #ifndef MSGPACK_RPC_SESSION_IMPL_H__
 #define MSGPACK_RPC_SESSION_IMPL_H__
 
-#include <boost/enable_shared_from_this.hpp>
 #include "session.h"
 #include "reqtable.h"
 #include "protocol.h"
 #include "transport_impl.h"
 #include "impl_fwd.h"
 
+#include <memory>
+
 namespace msgpack {
 namespace rpc {
 
 
-class session_impl : public boost::enable_shared_from_this<session_impl>
+class session_impl : public std::enable_shared_from_this<session_impl>
 {
 public:
     static shared_session create(const builder& b, const address addr, loop lo);

--- a/src/msgpack/rpc/session_pool.cc
+++ b/src/msgpack/rpc/session_pool.cc
@@ -22,6 +22,8 @@
 #include "exception_impl.h"
 #include "transport/tcp.h"
 
+#include <functional>
+
 namespace msgpack {
 namespace rpc {
 
@@ -182,7 +184,7 @@ static bool step_timeout(weak_session_pool wsp)
 
 void session_pool::start_timeout()
 {
-    get_loop()->add_timer(1, boost::bind(&step_timeout,
+    get_loop()->add_timer(1, std::bind(&step_timeout,
         weak_session_pool(m_pimpl)));
 }
 

--- a/src/msgpack/rpc/session_pool_impl.h
+++ b/src/msgpack/rpc/session_pool_impl.h
@@ -20,8 +20,9 @@
 
 #include "session_pool.h"
 #include "transport_impl.h"
-#include <boost/enable_shared_from_this.hpp>
+
 #include <boost/thread.hpp>
+#include <memory>
 
 namespace msgpack {
 namespace rpc {

--- a/src/msgpack/rpc/transport/dgram_handler.h
+++ b/src/msgpack/rpc/transport/dgram_handler.h
@@ -8,6 +8,7 @@
 #include "../types.h"
 
 #include <boost/asio.hpp>
+#include <memory>
 
 namespace msgpack {
 namespace rpc {
@@ -15,7 +16,7 @@ namespace rpc {
 class closed_exception : public std::exception { };
 
 class dgram_handler :  public message_sendable,
-    public boost::enable_shared_from_this<dgram_handler>
+    public std::enable_shared_from_this<dgram_handler>
 {
 public:
     dgram_handler(loop lo);
@@ -26,7 +27,7 @@ public:
     void start();
     void on_read(const boost::system::error_code& err, size_t nbytes);
 
-    boost::shared_ptr<message_sendable>
+    std::shared_ptr<message_sendable>
         get_response_sender(boost::asio::ip::udp::endpoint& ep);
 
     // message_sendable

--- a/src/msgpack/rpc/transport/stream_handler.cc
+++ b/src/msgpack/rpc/transport/stream_handler.cc
@@ -1,12 +1,7 @@
 #include "stream_handler.h"
 
-#include "../protocol.h"
-#include "../server_impl.h"
-#include "../session_impl.h"
-#include "../transport_impl.h"
-#include "../types.h"
-
 #include <boost/log/trivial.hpp>
+#include <functional>
 
 namespace msgpack {
 namespace rpc {
@@ -35,9 +30,8 @@ void stream_handler::start()
     m_pac->reserve_buffer(MSGPACK_RPC_STREAM_RESERVE_SIZE);
     m_socket.async_read_some(
         boost::asio::buffer(m_pac->buffer(), m_pac->buffer_capacity()),
-        m_strand.wrap(boost::bind(&stream_handler::on_read, shared_from_this(),
-            boost::asio::placeholders::error,
-            boost::asio::placeholders::bytes_transferred)));
+        m_strand.wrap(std::bind(&stream_handler::on_read, shared_from_this(),
+            std::placeholders::_1, std::placeholders::_2)));
 }
 
 void stream_handler::stop()

--- a/src/msgpack/rpc/transport/stream_handler.h
+++ b/src/msgpack/rpc/transport/stream_handler.h
@@ -7,6 +7,8 @@
 #include "../server_impl.h"
 #include "../transport_impl.h"
 
+#include <memory>
+
 namespace msgpack {
 namespace rpc {
 
@@ -14,15 +16,15 @@ class closed_exception : public std::exception { };
 
 
 class stream_handler :  public message_sendable,
-    public boost::enable_shared_from_this<stream_handler>
+    public std::enable_shared_from_this<stream_handler>
 {
 public:
     stream_handler(loop lo);
     virtual ~stream_handler();
 
     boost::asio::ip::tcp::socket& socket() { return m_socket; }
-    boost::shared_ptr<message_sendable> get_response_sender() {
-        return boost::static_pointer_cast<message_sendable>(shared_from_this());
+    std::shared_ptr<message_sendable> get_response_sender() {
+        return std::static_pointer_cast<message_sendable>(shared_from_this());
     }
 
     void start();
@@ -43,7 +45,7 @@ public:
     virtual void on_system_error(const boost::system::error_code& err) = 0;
 
 protected:
-    boost::scoped_ptr<unpacker> m_pac;
+    std::unique_ptr<unpacker> m_pac;
     boost::asio::ip::tcp::socket m_socket;
     boost::asio::io_service::strand m_strand;
     boost::mutex mutex;

--- a/src/msgpack/rpc/transport/tcp.h
+++ b/src/msgpack/rpc/transport/tcp.h
@@ -20,6 +20,8 @@
 
 #include "../transport.h"
 
+#include <memory>
+
 namespace msgpack {
 namespace rpc {
 

--- a/src/msgpack/rpc/transport/udp.cc
+++ b/src/msgpack/rpc/transport/udp.cc
@@ -66,7 +66,7 @@ public:
 
 private:
     session_impl* m_session;
-    boost::shared_ptr<client_socket> m_conn;
+    std::shared_ptr<client_socket> m_conn;
     boost::asio::io_service::work m_work;
 
 private:
@@ -201,7 +201,7 @@ public:
 
 private:
     weak_server m_wsvr;
-    boost::shared_ptr<server_socket> m_conn;
+    std::shared_ptr<server_socket> m_conn;
 
 private:
     server_transport();
@@ -256,7 +256,7 @@ void server_socket::on_notify(
 server_transport::server_transport(server_impl* svr, const address& addr)
 {
     m_wsvr = weak_server(
-        boost::static_pointer_cast<server_impl>(svr->shared_from_this()));
+        std::static_pointer_cast<server_impl>(svr->shared_from_this()));
 
     m_conn.reset(new transport::udp::server_socket(m_wsvr.lock()));
     m_conn->listen(addr);

--- a/src/msgpack/rpc/transport/udp.h
+++ b/src/msgpack/rpc/transport/udp.h
@@ -20,6 +20,8 @@
 
 #include "../transport.h"
 
+#include <memory>
+
 namespace msgpack {
 namespace rpc {
 

--- a/src/msgpack/rpc/types.h
+++ b/src/msgpack/rpc/types.h
@@ -18,15 +18,15 @@
 #ifndef MSGPACK_RPC_TYPES_H__
 #define MSGPACK_RPC_TYPES_H__
 
+#include <memory>
 #include <msgpack.hpp>
-#include <boost/shared_ptr.hpp>
 
 namespace msgpack {
 namespace rpc {
 
 
 typedef std::unique_ptr<zone> auto_zone;
-typedef boost::shared_ptr<zone> shared_zone;
+typedef std::shared_ptr<zone> shared_zone;
 
 
 template <typename T>

--- a/test/async_call.cc
+++ b/test/async_call.cc
@@ -3,8 +3,8 @@
 #include <boost/log/core.hpp>
 #include <boost/log/expressions.hpp>
 #include <boost/log/trivial.hpp>
-#include <boost/make_shared.hpp>
 #include <iostream>
+#include <memory>
 #include <msgpack/rpc/server.h>
 #include <msgpack/rpc/session_pool.h>
 #include <signal.h>
@@ -16,7 +16,7 @@ int main(int argc, char **argv)
 
     // run server {
     rpc::server svr;
-    svr.serve(boost::make_shared<myecho>());
+    svr.serve(std::make_shared<myecho>());
 
     svr.listen("0.0.0.0", 18811);
     svr.start(4);

--- a/test/async_server.cc
+++ b/test/async_server.cc
@@ -1,10 +1,11 @@
 #include "echo_server.h"
 
-#include <boost/bind.hpp>
 #include <boost/log/core.hpp>
 #include <boost/log/expressions.hpp>
 #include <boost/log/trivial.hpp>
+#include <functional>
 #include <iostream>
+#include <memory>
 #include <msgpack/rpc/server.h>
 #include <msgpack/rpc/client.h>
 #include <signal.h>
@@ -32,7 +33,7 @@ public:
 
         rpc::session s = m_svr->get_session("127.0.0.1", 18811);
         rpc::future f = s.call(method, params.get<0>(), params.get<1>());
-        f.attach_callback( boost::bind(&callback, _1, req) );
+        f.attach_callback(std::bind(&callback, std::placeholders::_1, req));
     }
     
 private:
@@ -47,7 +48,7 @@ int main(int argc, char **argv)
     // run server {
     rpc::server svr;
 
-    svr.serve(boost::make_shared<myecho>());
+    svr.serve(std::make_shared<myecho>());
     svr.listen("0.0.0.0", 18811);
 
     svr.start(4);
@@ -57,7 +58,7 @@ int main(int argc, char **argv)
     // run pxocy server {
     rpc::server proxy;
 
-    proxy.serve(boost::make_shared<myproxy>(&proxy));
+    proxy.serve(std::make_shared<myproxy>(&proxy));
     proxy.listen("0.0.0.0", 18812);
 
     proxy.start(4);

--- a/test/attack.h
+++ b/test/attack.h
@@ -2,7 +2,9 @@
 
 #include <boost/log/trivial.hpp>
 #include <boost/thread.hpp>
+#include <functional>
 #include <iostream>
+#include <memory>
 #include <msgpack/rpc/server.h>
 #include <msgpack/rpc/client.h>
 #include <msgpack/rpc/transport/tcp.h>
@@ -59,7 +61,7 @@ public:
 		m_svr->start(nthreads);
 	}
 
-	void start_attacker(size_t nthreads, boost::function<void ()> func)
+	void start_attacker(size_t nthreads, std::function<void ()> func)
 	{
 		m_threads.resize(nthreads);
 		m_times.resize(nthreads);
@@ -68,7 +70,7 @@ public:
 		for(size_t i=0; i < m_nthreads; ++i) {
 			m_times[i] = 0;
 			m_threads[i] = new boost::thread(
-					boost::bind(attacker::thread_main, func, &m_times[i]));
+					std::bind(attacker::thread_main, func, &m_times[i]));
 		}
 	}
 
@@ -105,7 +107,7 @@ public:
 			<< "variance      : " << var << std::endl;
 	}
 
-	void run(size_t nthreads, boost::function<void ()> func)
+	void run(size_t nthreads, std::function<void ()> func)
 	{
 		start_server();
 		start_attacker(nthreads, func);
@@ -122,13 +124,13 @@ private:
 	std::unique_ptr<rpc::builder> m_builder;
 
 	std::unique_ptr<rpc::server> m_svr;
-	boost::shared_ptr<rpc::dispatcher> m_dp;
+	std::shared_ptr<rpc::dispatcher> m_dp;
 
 	size_t m_nthreads;
 	std::vector<boost::thread*> m_threads;
 	std::vector<double> m_times;
 
-	static void thread_main(boost::function<void ()> func, double* time)
+	static void thread_main(std::function<void ()> func, double* time)
 	{
 		struct timeval start_time;
 		gettimeofday(&start_time, NULL);

--- a/test/attack_callback.cc
+++ b/test/attack_callback.cc
@@ -3,6 +3,7 @@
 #include <boost/log/core.hpp>
 #include <boost/log/expressions.hpp>
 #include <boost/log/trivial.hpp>
+#include <functional>
 #include <iostream>
 #include <signal.h>
 #include <vector>
@@ -43,7 +44,7 @@ void attack_callback()
         for(size_t j=0; j < ATTACK_DEPTH; ++j) {
             pipeline[j] = s.call("echo_huge", msglife, msg);
             pipeline[j].attach_callback(
-                    boost::bind(callback_func, _1, msg, msglife));
+                    std::bind(callback_func, std::placeholders::_1, msg, msglife));
         }
 
         for(size_t j=0; j < ATTACK_DEPTH; ++j) {

--- a/test/callback.cc
+++ b/test/callback.cc
@@ -3,7 +3,9 @@
 #include <boost/log/core.hpp>
 #include <boost/log/expressions.hpp>
 #include <boost/log/trivial.hpp>
+#include <functional>
 #include <iostream>
+#include <memory>
 #include <msgpack/rpc/server.h>
 #include <msgpack/rpc/session_pool.h>
 #include <signal.h>
@@ -28,7 +30,7 @@ int main(int argc, char **argv)
     // run server {
     rpc::server svr;
 
-    svr.serve(boost::make_shared<myecho>());
+    svr.serve(std::make_shared<myecho>());
     svr.listen("0.0.0.0", 18811);
 
     svr.start(4);
@@ -46,7 +48,7 @@ int main(int argc, char **argv)
     rpc::future f = s.call("add", 1, 2);
 
     f.attach_callback(
-        boost::bind(add_callback, _1, sp.get_loop()));
+        std::bind(add_callback, std::placeholders::_1, sp.get_loop()));
 
     sp.run(4);
 

--- a/test/notify.cc
+++ b/test/notify.cc
@@ -3,6 +3,7 @@
 #include <boost/log/core.hpp>
 #include <boost/log/expressions.hpp>
 #include <boost/log/trivial.hpp>
+#include <memory>
 #include <msgpack/rpc/server.h>
 #include <msgpack/rpc/client.h>
 #include <signal.h>
@@ -15,7 +16,7 @@ int main(int argc, char **argv)
     // run server {
     rpc::server svr;
 
-    svr.serve(boost::make_shared<myecho>());
+    svr.serve(std::make_shared<myecho>());
     svr.listen("0.0.0.0", 18811);
 
     svr.start(4);

--- a/test/sync_call.cc
+++ b/test/sync_call.cc
@@ -4,6 +4,7 @@
 #include <boost/log/expressions.hpp>
 #include <boost/log/trivial.hpp>
 #include <iostream>
+#include <memory>
 #include <msgpack/rpc/server.h>
 #include <msgpack/rpc/client.h>
 #include <signal.h>
@@ -16,7 +17,7 @@ int main(int argc, char **argv)
     // run server {
     rpc::server svr;
 
-    svr.serve(boost::make_shared<myecho>());
+    svr.serve(std::make_shared<myecho>());
     svr.listen("0.0.0.0", 18811);
 
     svr.start(4);

--- a/test/udp.cc
+++ b/test/udp.cc
@@ -4,6 +4,7 @@
 #include <boost/log/expressions.hpp>
 #include <boost/log/trivial.hpp>
 #include <iostream>
+#include <memory>
 #include <msgpack/rpc/server.h>
 #include <msgpack/rpc/client.h>
 #include <msgpack/rpc/transport/udp.h>
@@ -17,7 +18,7 @@ int main(int argc, char **argv)
     // run server {
     rpc::server svr;
 
-    svr.serve(boost::make_shared<myecho>());
+    svr.serve(std::make_shared<myecho>());
     svr.listen( msgpack::rpc::udp_listener("0.0.0.0", 18811) );
 
     svr.start(4);

--- a/unittest/unittest.cpp
+++ b/unittest/unittest.cpp
@@ -6,7 +6,7 @@
 #include <boost/log/core.hpp>
 #include <boost/log/expressions.hpp>
 #include <boost/log/trivial.hpp>
-#include <boost/make_shared.hpp>
+#include <memory>
 #include <msgpack/rpc/client.h>
 #include <msgpack/rpc/server.h>
 #include <msgpack/rpc/exception.h>
@@ -30,7 +30,7 @@ TEST(EchoServer, Add)
         const int PORT = 18811;
         msgpack::rpc::server server;
 
-        server.serve(boost::make_shared<myecho>());
+        server.serve(std::make_shared<myecho>());
         server.listen("0.0.0.0", PORT);
         server.start(5);
 
@@ -60,13 +60,12 @@ TEST(EchoServer, IncorrectPort)
 {
     using namespace msgpack;
     using namespace msgpack::rpc;
-    using namespace boost;
 
     try {
         const int PORT = 18811;
         msgpack::rpc::server server;
 
-        server.serve(boost::make_shared<myecho>());
+        server.serve(std::make_shared<myecho>());
         server.listen("0.0.0.0", PORT);
 
         msgpack::rpc::client cli("127.0.0.1", 16296);
@@ -90,13 +89,12 @@ TEST(EchoServer, NoMethodError)
 {
     using namespace msgpack;
     using namespace msgpack::rpc;
-    using namespace boost;
 
     try {
         const int PORT = 18811;
         msgpack::rpc::server server;
 
-        server.serve(boost::make_shared<myecho>());
+        server.serve(std::make_shared<myecho>());
         server.listen("0.0.0.0", PORT);
         server.start(1);
 
@@ -121,13 +119,12 @@ TEST(EchoServer, TimeoutErrorSession)
 {
     using namespace msgpack;
     using namespace msgpack::rpc;
-    using namespace boost;
 
     try {
         const int PORT = 18811;
         msgpack::rpc::server server;
 
-        server.serve(boost::make_shared<myecho>());
+        server.serve(std::make_shared<myecho>());
         server.listen("0.0.0.0", PORT);
         server.start(1);
 
@@ -152,13 +149,12 @@ TEST(EchoServer, TimeoutErrorClient)
 {
     using namespace msgpack;
     using namespace msgpack::rpc;
-    using namespace boost;
 
     try {
         const int PORT = 18811;
         msgpack::rpc::server server;
 
-        server.serve(boost::make_shared<myecho>());
+        server.serve(std::make_shared<myecho>());
         server.listen("0.0.0.0", PORT);
         server.start(1);
 
@@ -181,13 +177,12 @@ TEST(EchoServer, Err)
 {
     using namespace msgpack;
     using namespace msgpack::rpc;
-    using namespace boost;
 
     try {
         const int PORT = 18811;
         msgpack::rpc::server server;
 
-        server.serve(boost::make_shared<myecho>());
+        server.serve(std::make_shared<myecho>());
         server.listen("0.0.0.0", PORT);
         server.start(5);
 
@@ -211,13 +206,12 @@ TEST(EchoServer, Notify)
 {
     using namespace msgpack;
     using namespace msgpack::rpc;
-    using namespace boost;
 
     try {
         const int PORT = 18811;
         msgpack::rpc::server server;
 
-        server.serve(boost::make_shared<myecho>());
+        server.serve(std::make_shared<myecho>());
         server.listen("0.0.0.0", PORT);
         server.start(5);
 


### PR DESCRIPTION
I first tried doing std::shared_ptr by itself, but ran into some
build issues in boost::bind() calls so I converted those as well.

As a bonus, I also updated the one instance of boost::scoped_ptr
to the C++11 equivalent std::unique_ptr, as that's already used
in other parts of this project's code.
