### PR TITLE
Use std::make_shared to convert to shared_ptr.

### DIFF
--- a/src/msgpack/rpc/server.cc
+++ b/src/msgpack/rpc/server.cc
@@ -97,12 +97,12 @@ void server_impl::on_notify(
 // SERVER
 
 server::server(loop lo) :
-    session_pool(shared_session_pool(new server_impl(tcp_builder(), lo)))
+    session_pool(shared_session_pool(std::make_shared<server_impl>(tcp_builder(), lo)))
 {
 }
 
 server::server(const builder& b, loop lo) :
-    session_pool(shared_session_pool(new server_impl(b, lo)))
+    session_pool(shared_session_pool(std::make_shared<server_impl>(b, lo)))
 {
 }
 


### PR DESCRIPTION
Faster and also works around http://llvm.org/bugs/show_bug.cgi?id=18843 on Mac.
