### PR TITLE
Add "shared" option (on by default), which can be used to control library type.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,18 +11,19 @@ set(CMAKE_CXX_FLAGS "-std=c++11 -Wall ${CMAKE_CXX_FLAGS}")
 
 INCLUDE_DIRECTORIES(${CMAKE_SOURCE_DIR}/src)
 
-option(Boost_USE_STATIC_LIBS "Build with static Boost libraries." OFF)
-option(MessagePack_USE_STATIC_LIBS "Build with static MessagePack libraries." OFF)
+option(shared "build msgpack-rpc-boost as a shared library" ON)
 
-find_package (Boost REQUIRED COMPONENTS COMPONENTS system thread filesystem regex log)
-
-if(NOT Boost_USE_STATIC_LIBS)
+if(NOT shared)
+    set(Boost_USE_STATIC_LIBS ON)
+else()
     add_definitions(-DBOOST_ALL_DYN_LINK)
 endif()
 
+find_package (Boost REQUIRED COMPONENTS COMPONENTS system thread filesystem regex log)
+
 find_package (OpenSSL QUIET)
 
-if(MessagePack_USE_STATIC_LIBS)
+if(NOT shared)
     set( _messagepack_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES})
     set(CMAKE_FIND_LIBRARY_SUFFIXES .a)
 endif()
@@ -36,7 +37,7 @@ if (MSGPACK_INCLUDE_DIR-NOTFOUND)
     message (FATAL_ERROR "The msgpack header was not found on your system.")
 endif (MSGPACK_INCLUDE_DIR-NOTFOUND)
 
-if(MessagePack_USE_STATIC_LIBS)
+if(NOT shared)
     set(CMAKE_FIND_LIBRARY_SUFFIXES ${_messagepack_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES})
 endif()
 

--- a/src/msgpack/rpc/CMakeLists.txt
+++ b/src/msgpack/rpc/CMakeLists.txt
@@ -24,18 +24,17 @@ SET(MSGPACK_RPC_TRANSPORT_SRC
     transport/dgram_handler.cc
 )
 
-ADD_LIBRARY(mprpc-static STATIC
-    ${MSGPACK_RPC_SRC}
-    ${MSGPACK_RPC_TRANSPORT_SRC}
-)
-
-ADD_LIBRARY(mprpc-shared SHARED 
-    ${MSGPACK_RPC_SRC}
-    ${MSGPACK_RPC_TRANSPORT_SRC}
-)
-
-SET_TARGET_PROPERTIES(mprpc-static PROPERTIES OUTPUT_NAME mprpc)
-SET_TARGET_PROPERTIES(mprpc-shared PROPERTIES OUTPUT_NAME mprpc)
+IF(shared)
+    ADD_LIBRARY(mprpc SHARED
+        ${MSGPACK_RPC_SRC}
+        ${MSGPACK_RPC_TRANSPORT_SRC}
+    )
+ELSE()
+    ADD_LIBRARY(mprpc STATIC
+        ${MSGPACK_RPC_SRC}
+        ${MSGPACK_RPC_TRANSPORT_SRC}
+    )
+ENDIF()
 
 ##########################################
 
@@ -65,7 +64,7 @@ SET(MPRPC_TRANSPORT_HEADERS
 
 INSTALL(FILES ${MPRPC_HEADERS} DESTINATION include/msgpack/rpc)
 INSTALL(FILES ${MPRPC_TRANSPORT_HEADERS} DESTINATION include/msgpack/rpc/transport)
-INSTALL(TARGETS mprpc-static mprpc-shared
+INSTALL(TARGETS mprpc
     LIBRARY DESTINATION lib
     ARCHIVE DESTINATION lib
 )


### PR DESCRIPTION
If shared is OFF, it will output a static library. If static, it assumes a statically built Boost and msgpack-c dependency.
