### PR TITLE
Require BOOST_ASIO_SEPARATE_COMPILATION for static libraries.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,10 +13,11 @@ INCLUDE_DIRECTORIES(${CMAKE_SOURCE_DIR}/src)
 
 option(shared "build msgpack-rpc-boost as a shared library" ON)
 
-if(NOT shared)
-    set(Boost_USE_STATIC_LIBS ON)
-else()
+if(shared)
     add_definitions(-DBOOST_ALL_DYN_LINK)
+else()
+    set(Boost_USE_STATIC_LIBS ON)
+    add_definitions(-DBOOST_ASIO_SEPARATE_COMPILATION)
 endif()
 
 find_package (Boost REQUIRED COMPONENTS COMPONENTS system thread filesystem regex log)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,35 +2,35 @@ cmake_minimum_required(VERSION 2.8)
 
 PROJECT(test)
 
-add_executable(address_test address_test.cc)
+add_executable(address_test address_test.cc asio.cc)
 target_link_libraries (address_test mprpc-static)
 
-add_executable(sync_call sync_call.cc)
+add_executable(sync_call sync_call.cc asio.cc)
 target_link_libraries (sync_call mprpc-static)
 
-add_executable(async_call async_call.cc)
+add_executable(async_call async_call.cc asio.cc)
 target_link_libraries (async_call mprpc-static)
 
-add_executable(callback callback.cc)
+add_executable(callback callback.cc asio.cc)
 target_link_libraries (callback mprpc-static)
 
-add_executable(notify notify.cc)
+add_executable(notify notify.cc asio.cc)
 target_link_libraries (notify mprpc-static)
 
-add_executable(async_server async_server.cc)
+add_executable(async_server async_server.cc asio.cc)
 target_link_libraries (async_server mprpc-static)
 
-add_executable(udp udp.cc)
+add_executable(udp udp.cc asio.cc)
 target_link_libraries (udp mprpc-static)
 
-add_executable(attack_connect attack_connect.cc)
+add_executable(attack_connect attack_connect.cc asio.cc)
 target_link_libraries (attack_connect mprpc-static)
 
-add_executable(attack_pipeline attack_pipeline.cc)
+add_executable(attack_pipeline attack_pipeline.cc asio.cc)
 target_link_libraries (attack_pipeline mprpc-static)
 
-add_executable(attack_huge attack_huge.cc)
+add_executable(attack_huge attack_huge.cc asio.cc)
 target_link_libraries (attack_huge mprpc-static)
 
-add_executable(attack_callback attack_callback.cc)
+add_executable(attack_callback attack_callback.cc asio.cc)
 target_link_libraries (attack_callback mprpc-static)

--- a/test/asio.cc
+++ b/test/asio.cc
@@ -1,0 +1,4 @@
+// Include Boost.Asio source code if not used as header-only library.
+#if defined(BOOST_ASIO_DYN_LINK) || defined(BOOST_ASIO_SEPARATE_COMPILATION)
+#include <boost/asio/impl/src.hpp>
+#endif

--- a/unittest/CMakeLists.txt
+++ b/unittest/CMakeLists.txt
@@ -7,6 +7,8 @@ find_package (GTest REQUIRED)
 include_directories(${GTEST_INCLUDE_DIRS})
 
 file(GLOB_RECURSE SRCS_UNITTEST *.c*)
+list(APPEND SRCS_UNITTEST ${CMAKE_CURRENT_SOURCE_DIR}/../test/asio.cc)
+
 add_executable(unittest ${SRCS_UNITTEST})
 TARGET_LINK_LIBRARIES(unittest mprpc-static
     ${GTEST_LIBRARIES}


### PR DESCRIPTION
This is consistent with requiring BOOST_ASIO_DYN_LINK for shared
libraries, and makes more sense for being a library.

Requires the library user to include <boost/asio/impl/src.hpp>
in a separate compilation unit, ideally in the top-level project,
which is then picked up by the (static or shared) library.
